### PR TITLE
Fixing fatal typo.

### DIFF
--- a/include/atlas/core/Constants.hpp
+++ b/include/atlas/core/Constants.hpp
@@ -88,7 +88,7 @@ namespace atlas
         template <typename GenType>
         constexpr GenType max()
         {
-            retun std::numeric_limits<GenType>::max();
+            return std::numeric_limits<GenType>::max();
         }
 
         /**


### PR DESCRIPTION
Typo would not allow library to be built.