### PR TITLE
Makes all Ray comparison operators const

### DIFF
--- a/include/atlas/math/Ray.hpp
+++ b/include/atlas/math/Ray.hpp
@@ -7,10 +7,10 @@ namespace atlas::math
     template<typename T>
     struct Ray
     {
-        constexpr Ray() : o{0.0f}, d{0.0f}
+        Ray() : o{0.0f}, d{0.0f}
         {}
 
-        constexpr Ray(T const& origin, T const& dir) : o{origin}, d{dir}
+        Ray(T const& origin, T const& dir) : o{origin}, d{dir}
         {}
 
         T operator()(float t) const

--- a/include/atlas/math/Ray.hpp
+++ b/include/atlas/math/Ray.hpp
@@ -7,10 +7,10 @@ namespace atlas::math
     template<typename T>
     struct Ray
     {
-        Ray() : o{0.0f}, d{0.0f}
+        constexpr Ray() : o{0.0f}, d{0.0f}
         {}
 
-        Ray(T const& origin, T const& dir) : o{origin}, d{dir}
+        constexpr Ray(T const& origin, T const& dir) : o{origin}, d{dir}
         {}
 
         T operator()(float t) const
@@ -18,12 +18,12 @@ namespace atlas::math
             return o + (t * d);
         }
 
-        bool operator==(Ray const& rhs)
+        bool operator==(Ray const& rhs) const
         {
             return (o == rhs.o) && (d == rhs.d);
         }
 
-        bool operator!=(Ray const& rhs)
+        bool operator!=(Ray const& rhs) const
         {
             return !(*this == rhs);
         }


### PR DESCRIPTION
Edited `Ray` comparison operators to be `const`, since they clearly do not make modifications to data members.